### PR TITLE
No runtime in usage tests

### DIFF
--- a/samples/wildcardExport/sample.js
+++ b/samples/wildcardExport/sample.js
@@ -4,7 +4,7 @@ import expect from 'expect.js';
 
 describe('wildcard export of imported object', () => {
   it('has objects exported from namedExports', () => {
-    expect(wildcardImport.test1).to.eq(test1);
-    expect(wildcardImport.test2).to.eq(test2);
+    expect(wildcardImport.test1).to.equal(test1);
+    expect(wildcardImport.test2).to.equal(test2);
   });
 });

--- a/usage-tests/BabelRewirePluginUsageTest.js
+++ b/usage-tests/BabelRewirePluginUsageTest.js
@@ -18,7 +18,6 @@ function transformSampleCodeToTestWithBabelPluginRewire(source, filename) {
 		"plugins": [
 			babelPluginRewire,
 			"syntax-async-functions",
-			"transform-runtime",
 			"transform-es2015-block-scoping",
 			"transform-es2015-template-literals",
 			"transform-es2015-typeof-symbol",


### PR DESCRIPTION
This fixes the issue you had with your tests in https://github.com/speedskater/babel-plugin-rewire/issues/78#issuecomment-163715544

The `usage-tests/BabelRewirePluginUsageTest.js` had very useful code (which was commented out) to output the compiled source code. I used that as the base for the debugging.
